### PR TITLE
Reorder locale information consistently

### DIFF
--- a/lib/currency-locales/locales/ae.yml
+++ b/lib/currency-locales/locales/ae.yml
@@ -1,26 +1,23 @@
 ae:
   number:
-    format:
-      separator: "."
-      delimiter: ","
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%u %n"
-        unit: "AED"
-        separator: "."
         delimiter: ","
+        format: "%u %n"
         precision: 2
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "AED"
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: ","

--- a/lib/currency-locales/locales/af.yml
+++ b/lib/currency-locales/locales/af.yml
@@ -1,0 +1,50 @@
+---
+af:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%u %n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: R
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: miljard
+          million: miljoen
+          quadrillion: biljard
+          thousand: duisend
+          trillion: biljoen
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Greep
+            other: Grepe
+          gb: GG
+          kb: kG
+          mb: MG
+          tb: TG
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/ar.yml
+++ b/lib/currency-locales/locales/ar.yml
@@ -1,0 +1,54 @@
+---
+ar:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u %n"
+        precision: 3
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: KWD
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: مليار
+          million: مليون
+          quadrillion: كدريليون
+          thousand: ألفّ
+          trillion: تريليون
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            zero: Bytes
+            one: Byte
+            two: Bytes
+            few: Bytes
+            many: Bytes
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/az.yml
+++ b/lib/currency-locales/locales/az.yml
@@ -1,0 +1,49 @@
+---
+az:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: AZN
+    format:
+      delimiter: " "
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Milyard
+          million: Milyon
+          quadrillion: Kvadrilyon
+          thousand: Min
+          trillion: Trilyon
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Bayt
+            other: Bayt
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/be.yml
+++ b/lib/currency-locales/locales/be.yml
@@ -1,0 +1,74 @@
+---
+be:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: руб.
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: мільярд
+            few: мільярда
+            many: мільярдаў
+            other: мільярда
+          million:
+            one: мільён
+            few: мільёна
+            many: мільёнаў
+            other: мільёна
+          quadrillion:
+            one: квадрыльён
+            few: квадрыльёна
+            many: квадрыльёнаў
+            other: квадрыльёна
+          thousand:
+            one: тысяча
+            few: тысячы
+            many: тысяч
+            other: тысячы
+          trillion:
+            one: трыльён
+            few: трыльёна
+            many: трыльёнаў
+            other: трыльёна
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: байт
+            few: байта
+            many: байтаў
+            other: байта
+          eb: ЭБ
+          gb: ГБ
+          kb: КБ
+          mb: МБ
+          pb: ПБ
+          tb: ТБ
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/bg.yml
+++ b/lib/currency-locales/locales/bg.yml
@@ -1,22 +1,19 @@
 bg:
   number:
-    format:
-      precision: 2
-      separator: ","
-      delimiter: " "
-
     currency:
       format:
-        unit: 'лв'
-        precision: 2
-        format: '%n%u'
-        separator: ","
         delimiter: " "
-
-  percentage:
+        format: '%n%u'
+        precision: 2
+        separator: ","
+        unit: 'лв'
     format:
       delimiter: " "
-        
-  precision:
-    format:
-      delimiter: " "
+      precision: 2
+      separator: ","
+    percentage:
+      format:
+        delimiter: " "
+    precision:
+      format:
+        delimiter: " "

--- a/lib/currency-locales/locales/bn.yml
+++ b/lib/currency-locales/locales/bn.yml
@@ -1,0 +1,44 @@
+---
+bn:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u %n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "৳"
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: বাইট
+            other: বাইট
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/bs.yml
+++ b/lib/currency-locales/locales/bs.yml
@@ -1,0 +1,72 @@
+---
+bs:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n%u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: true
+        unit: KM
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: true
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: milijarda
+            few: milijarde
+            many: milijardi
+            other: milijardi
+          million:
+            one: milion
+            few: miliona
+            many: miliona
+            other: miliona
+          quadrillion:
+            one: bilijarda
+            few: bilijarde
+            many: bilijardi
+            other: bilijardi
+          thousand:
+            one: hiljada
+            few: hiljade
+            many: hiljada
+            other: hiljada
+          trillion:
+            one: bilion
+            few: biliona
+            many: biliona
+            other: biliona
+          unit: ''
+      format:
+        delimiter: ","
+        precision: 0
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: bajt
+            few: bajta
+            many: bajtova
+            other: bajtova
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ","
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/ca.yml
+++ b/lib/currency-locales/locales/ca.yml
@@ -1,0 +1,60 @@
+---
+ca:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil milions
+          million:
+            one: milió
+            other: milions
+          quadrillion:
+            one: quadrilió
+            other: quadrilions
+          thousand:
+            one: miler
+            other: milers
+          trillion:
+            one: bilió
+            other: bilions
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/cnr.yml
+++ b/lib/currency-locales/locales/cnr.yml
@@ -1,0 +1,72 @@
+---
+cnr:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: true
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: true
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: milijarda
+            few: milijarde
+            many: milijardi
+            other: milijardi
+          million:
+            one: milion
+            few: miliona
+            many: miliona
+            other: miliona
+          quadrillion:
+            one: bilijarda
+            few: bilijarde
+            many: bilijardi
+            other: bilijardi
+          thousand:
+            one: hiljada
+            few: hiljade
+            many: hiljada
+            other: hiljada
+          trillion:
+            one: bilion
+            few: biliona
+            many: biliona
+            other: biliona
+          unit: ''
+      format:
+        delimiter: ","
+        precision: 0
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: bajt
+            few: bajta
+            many: bajtova
+            other: bajtova
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ","
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/cs.yml
+++ b/lib/currency-locales/locales/cs.yml
@@ -1,26 +1,23 @@
 cs:
   number:
-    format:
-      separator: ","
-      delimiter: " "
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%n %u"
-        unit: "Kč"
-        separator: ","
         delimiter: " "
+        format: "%n %u"
         precision: 2
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "Kč"
+    format:
+      delimiter: " "
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: " "

--- a/lib/currency-locales/locales/cy.yml
+++ b/lib/currency-locales/locales/cy.yml
@@ -1,0 +1,55 @@
+---
+cy:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "£"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Biliwn
+          million: Miliwn
+          quadrillion: Cwadriliwn
+          thousand: Mil
+          trillion: Triliwn
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            zero: Bytes
+            one: Byte
+            two: Bytes
+            few: Bytes
+            many: Bytes
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+          eb: EB
+          pb: PB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/da.yml
+++ b/lib/currency-locales/locales/da.yml
@@ -1,14 +1,14 @@
 da:
   number:
-  currency:
-    format:
-      delimiter: "."
-      format: "%n %u"
-      precision: 2
-      separator: ","
-      significant: false
-      strip_insignificant_zeros: false
-      unit: "kr"
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "kr"
     format:
       delimiter: "."
       precision: 2

--- a/lib/currency-locales/locales/da.yml
+++ b/lib/currency-locales/locales/da.yml
@@ -1,26 +1,23 @@
 da:
   number:
+  currency:
     format:
-      separator: ","
       delimiter: "."
+      format: "%n %u"
       precision: 2
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
-
-    currency:
-      format:
-        format: "%n %u"
-        unit: "kr"
-        separator: ","
-        delimiter: "."
-        precision: 2
-        significant: false
-        strip_insignificant_zeros: false
-
+      unit: "kr"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: "."

--- a/lib/currency-locales/locales/de-AT.yml
+++ b/lib/currency-locales/locales/de-AT.yml
@@ -1,0 +1,61 @@
+---
+de-AT:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u %n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: Milliarde
+            other: Milliarden
+          million:
+            one: Million
+            other: Millionen
+          quadrillion:
+            one: Billiarde
+            other: Billiarden
+          thousand: Tausend
+          trillion:
+            one: Billion
+            other: Billionen
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/de-CH.yml
+++ b/lib/currency-locales/locales/de-CH.yml
@@ -1,0 +1,61 @@
+---
+de-CH:
+  number:
+    currency:
+      format:
+        delimiter: "'"
+        format: "%u %n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: CHF
+    format:
+      delimiter: "'"
+      precision: 2
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: Milliarde
+            other: Milliarden
+          million:
+            one: Million
+            other: Millionen
+          quadrillion:
+            one: Billiarde
+            other: Billiarden
+          thousand: Tausend
+          trillion:
+            one: Billion
+            other: Billionen
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/de-DE.yml
+++ b/lib/currency-locales/locales/de-DE.yml
@@ -1,0 +1,61 @@
+---
+de-DE:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: Milliarde
+            other: Milliarden
+          million:
+            one: Million
+            other: Millionen
+          quadrillion:
+            one: Billiarde
+            other: Billiarden
+          thousand: Tausend
+          trillion:
+            one: Billion
+            other: Billionen
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/de.yml
+++ b/lib/currency-locales/locales/de.yml
@@ -1,0 +1,61 @@
+---
+de:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: Milliarde
+            other: Milliarden
+          million:
+            one: Million
+            other: Millionen
+          quadrillion:
+            one: Billiarde
+            other: Billiarden
+          thousand: Tausend
+          trillion:
+            one: Billion
+            other: Billionen
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/dz.yml
+++ b/lib/currency-locales/locales/dz.yml
@@ -1,0 +1,52 @@
+---
+dz:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: ༢
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: ༣
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: ཐེར་འབུམ
+          million: ས་ཡ
+          quadrillion: Quadrillion
+          thousand: སྟོང་ཕྲག
+          trillion: ཁྲག་ཁྲིག་ཆེན་པོ
+          unit: ''
+      format:
+        delimiter: ''
+        precision: ༣
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/el-CY.yml
+++ b/lib/currency-locales/locales/el-CY.yml
@@ -1,0 +1,52 @@
+---
+el-CY:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: δισεκατομμύριο
+          million: εκατομμύριο
+          quadrillion: τετράκις εκατομμύριο
+          thousand: χίλια
+          trillion: τρισεκατομμύριο
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/el.yml
+++ b/lib/currency-locales/locales/el.yml
@@ -1,0 +1,52 @@
+---
+el:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: δισεκατομμύριο
+          million: εκατομμύριο
+          quadrillion: τετράκις εκατομμύριο
+          thousand: χίλια
+          trillion: τρισεκατομμύριο
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/en-AU.yml
+++ b/lib/currency-locales/locales/en-AU.yml
@@ -1,26 +1,23 @@
 en-AU:
   number:
-    format:
-      separator: "."
-      delimiter: ","
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%u%n"
-        unit: "$"
-        separator: "."
         delimiter: ","
+        format: "%u%n"
         precision: 2
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: ","

--- a/lib/currency-locales/locales/en-CA.yml
+++ b/lib/currency-locales/locales/en-CA.yml
@@ -1,0 +1,52 @@
+---
+en-CA:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/en-CY.yml
+++ b/lib/currency-locales/locales/en-CY.yml
@@ -1,0 +1,52 @@
+---
+en-CY:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/en-GB.yml
+++ b/lib/currency-locales/locales/en-GB.yml
@@ -1,26 +1,23 @@
 en-GB:
   number:
-    format:
-      separator: "."
-      delimiter: ","
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%u%n"
-        unit: "£"
-        separator: "."
         delimiter: ","
+        format: "%u%n"
         precision: 2
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "£"
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: ","

--- a/lib/currency-locales/locales/en-IE.yml
+++ b/lib/currency-locales/locales/en-IE.yml
@@ -1,0 +1,52 @@
+---
+en-IE:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/en-IN.yml
+++ b/lib/currency-locales/locales/en-IN.yml
@@ -1,6 +1,7 @@
 en-IN:
   number:
     currency:
+      format:
         delimiter: ","
         format: "%u%n"
         precision: 2
@@ -8,7 +9,6 @@ en-IN:
         significant: false
         strip_insignificant_zeros: false
         unit: "₹"
-      format:
     format:
       delimiter: ","
       precision: 2

--- a/lib/currency-locales/locales/en-IN.yml
+++ b/lib/currency-locales/locales/en-IN.yml
@@ -1,26 +1,23 @@
 en-IN:
   number:
-    format:
-      separator: "."
-      delimiter: ","
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
-      format:
-        format: "%u%n"
-        unit: "₹"
-        separator: "."
         delimiter: ","
+        format: "%u%n"
         precision: 2
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "₹"
+      format:
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: ","

--- a/lib/currency-locales/locales/en-NZ.yml
+++ b/lib/currency-locales/locales/en-NZ.yml
@@ -1,0 +1,52 @@
+---
+en-NZ:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/en-PH.yml
+++ b/lib/currency-locales/locales/en-PH.yml
@@ -1,26 +1,23 @@
 en-PH:
   number:
-    format:
-      separator: "."
-      delimiter: ","
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%u%n"
-        unit: "₱"
-        separator: "."
         delimiter: ","
+        format: "%u%n"
         precision: 2
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "₱"
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: ","

--- a/lib/currency-locales/locales/en-TT.yml
+++ b/lib/currency-locales/locales/en-TT.yml
@@ -1,0 +1,50 @@
+---
+en-TT:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: TT$
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/en-US.yml
+++ b/lib/currency-locales/locales/en-US.yml
@@ -1,26 +1,23 @@
 en-US:
   number:
-    format:
-      separator: "."
-      delimiter: ","
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%u%n"
-        unit: "$"
-        separator: "."
         delimiter: ","
+        format: "%u%n"
         precision: 2
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: ","

--- a/lib/currency-locales/locales/en-ZA.yml
+++ b/lib/currency-locales/locales/en-ZA.yml
@@ -1,0 +1,52 @@
+---
+en-ZA:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%u %n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: R
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/en.yml
+++ b/lib/currency-locales/locales/en.yml
@@ -1,0 +1,55 @@
+---
+en:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        negative_format: "-%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+          zb: ZB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/eo.yml
+++ b/lib/currency-locales/locales/eo.yml
@@ -1,0 +1,49 @@
+---
+eo:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: " "
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: miliardo
+          million: miliono
+          quadrillion: miliono da miliardoj
+          thousand: mil
+          trillion: mil miliardoj
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: bitoko
+            other: bitokoj
+          gb: Gb
+          kb: kb
+          mb: Mb
+          tb: Tb
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/es-419.yml
+++ b/lib/currency-locales/locales/es-419.yml
@@ -1,0 +1,57 @@
+---
+es-419:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "¤"
+    format:
+      delimiter: ","
+      precision: 2
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ","
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ","
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ","

--- a/lib/currency-locales/locales/es-AR.yml
+++ b/lib/currency-locales/locales/es-AR.yml
@@ -1,0 +1,57 @@
+---
+es-AR:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u%n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: "."
+      precision: 2
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ","
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ","
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ","

--- a/lib/currency-locales/locales/es-CL.yml
+++ b/lib/currency-locales/locales/es-CL.yml
@@ -1,0 +1,57 @@
+---
+es-CL:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u %n"
+        precision: 0
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: "."
+      precision: 3
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/es-CO.yml
+++ b/lib/currency-locales/locales/es-CO.yml
@@ -1,0 +1,57 @@
+---
+es-CO:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u%n"
+        precision: 0
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: "."
+      precision: 2
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/es-CR.yml
+++ b/lib/currency-locales/locales/es-CR.yml
@@ -1,0 +1,57 @@
+---
+es-CR:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "¢"
+    format:
+      delimiter: ","
+      precision: 2
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ","
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ","
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ","

--- a/lib/currency-locales/locales/es-EC.yml
+++ b/lib/currency-locales/locales/es-EC.yml
@@ -1,0 +1,57 @@
+---
+es-EC:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/es-ES.yml
+++ b/lib/currency-locales/locales/es-ES.yml
@@ -1,0 +1,57 @@
+---
+es-ES:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/es-MX.yml
+++ b/lib/currency-locales/locales/es-MX.yml
@@ -1,26 +1,23 @@
 es-MX:
   number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
     format:
       delimiter: ","
       precision: 2
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
-      separator: "."
-      
-    currency:
-      format:
-        format: "%u%n"
-        unit: "$"
-        separator: "."
-        delimiter: ","
-        precision: 2
-        significant: false
-        strip_insignificant_zeros: false
-
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: ","

--- a/lib/currency-locales/locales/es-NI.yml
+++ b/lib/currency-locales/locales/es-NI.yml
@@ -1,0 +1,57 @@
+---
+es-NI:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: C$
+    format:
+      delimiter: ","
+      precision: 2
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ","
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ","
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ","

--- a/lib/currency-locales/locales/es-PA.yml
+++ b/lib/currency-locales/locales/es-PA.yml
@@ -1,0 +1,57 @@
+---
+es-PA:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: B/.
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/es-PE.yml
+++ b/lib/currency-locales/locales/es-PE.yml
@@ -1,0 +1,57 @@
+---
+es-PE:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: S/
+    format:
+      delimiter: ","
+      precision: 2
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ","
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ","
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ","

--- a/lib/currency-locales/locales/es-US.yml
+++ b/lib/currency-locales/locales/es-US.yml
@@ -1,0 +1,57 @@
+---
+es-US:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 2
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ","
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ","
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ","

--- a/lib/currency-locales/locales/es-VE.yml
+++ b/lib/currency-locales/locales/es-VE.yml
@@ -1,0 +1,57 @@
+---
+es-VE:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u%n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: Bs.
+    format:
+      delimiter: "."
+      precision: 2
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: "."
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ","
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ","

--- a/lib/currency-locales/locales/es.yml
+++ b/lib/currency-locales/locales/es.yml
@@ -1,0 +1,57 @@
+---
+es:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/et.yml
+++ b/lib/currency-locales/locales/et.yml
@@ -1,0 +1,50 @@
+---
+et:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: " "
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: miljard
+          million: miljon
+          quadrillion: kvadriljon
+          thousand: tuhat
+          trillion: triljon
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: bait
+            other: baiti
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/eu.yml
+++ b/lib/currency-locales/locales/eu.yml
@@ -1,26 +1,23 @@
 eu:
   number:
-    format:
-      separator: ","
-      delimiter: "."
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%n %u"
-        unit: "€"
-        separator: ","
         delimiter: "."
+        format: "%n %u"
         precision: 2
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: "."

--- a/lib/currency-locales/locales/fa.yml
+++ b/lib/currency-locales/locales/fa.yml
@@ -1,0 +1,49 @@
+---
+fa:
+  number:
+    currency:
+      format:
+        delimiter: "٬"
+        format: "%n %u"
+        precision: 0
+        separator: "٫"
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "﷼"
+    format:
+      delimiter: "٬"
+      precision: 2
+      separator: "٫"
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: میلیارد
+          million: میلیون
+          quadrillion: کادریلیون
+          thousand: هزار
+          trillion: تریلیون
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: بایت
+            other: بایت
+          gb: گیگابایت
+          kb: کیلوبایت
+          mb: مگابایت
+          tb: ترابایت
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/fi.yml
+++ b/lib/currency-locales/locales/fi.yml
@@ -1,0 +1,49 @@
+---
+fi:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: " "
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: miljardia
+          million: miljoonaa
+          quadrillion: tuhatta biljoonaa
+          thousand: tuhatta
+          trillion: biljoonaa
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: tavu
+            other: tavua
+          gb: Gt
+          kb: kt
+          mb: Mt
+          tb: Tt
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/fr-CA.yml
+++ b/lib/currency-locales/locales/fr-CA.yml
@@ -1,0 +1,53 @@
+---
+fr-CA:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: " "
+      precision: 3
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: milliard
+          million: million
+          quadrillion: million de milliards
+          thousand: millier
+          trillion: billion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: octet
+            other: octets
+          eb: Eo
+          gb: Go
+          kb: ko
+          mb: Mo
+          pb: Po
+          tb: To
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/fr-CH.yml
+++ b/lib/currency-locales/locales/fr-CH.yml
@@ -1,0 +1,53 @@
+---
+fr-CH:
+  number:
+    currency:
+      format:
+        delimiter: "'"
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: sFr.
+    format:
+      delimiter: "'"
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: milliard
+          million: million
+          quadrillion: million de milliards
+          thousand: millier
+          trillion: billion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: octet
+            other: octets
+          eb: Eo
+          gb: Go
+          kb: ko
+          mb: Mo
+          pb: Po
+          tb: To
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/fr-FR.yml
+++ b/lib/currency-locales/locales/fr-FR.yml
@@ -1,0 +1,53 @@
+---
+fr-FR:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: " "
+      precision: 3
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: milliard
+          million: million
+          quadrillion: million de milliards
+          thousand: millier
+          trillion: billion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: octet
+            other: octets
+          eb: Eo
+          gb: Go
+          kb: ko
+          mb: Mo
+          pb: Po
+          tb: To
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/fr.yml
+++ b/lib/currency-locales/locales/fr.yml
@@ -1,0 +1,53 @@
+---
+fr:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: " "
+      precision: 3
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: milliard
+          million: million
+          quadrillion: million de milliards
+          thousand: millier
+          trillion: billion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: octet
+            other: octets
+          eb: Eo
+          gb: Go
+          kb: ko
+          mb: Mo
+          pb: Po
+          tb: To
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/fy.yml
+++ b/lib/currency-locales/locales/fy.yml
@@ -1,0 +1,52 @@
+---
+fy:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u %n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: miljard
+          million: miljoen
+          quadrillion: biljard
+          thousand: tûzen
+          trillion: biljoen
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: byte
+            other: bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/gd.yml
+++ b/lib/currency-locales/locales/gd.yml
@@ -1,0 +1,55 @@
+---
+gd:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "£"
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: billean
+          million: millean
+          quadrillion: quadrillean
+          thousand: mìle
+          trillion: trillean
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: bhaidht
+            two: bhaidht
+            few: baidhtean
+            other: baidht
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/gl.yml
+++ b/lib/currency-locales/locales/gl.yml
@@ -1,0 +1,44 @@
+---
+gl:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/gsw-CH.yml
+++ b/lib/currency-locales/locales/gsw-CH.yml
@@ -1,26 +1,23 @@
 gsw-CH:
   number:
-    format:
-      precision: 2
-      separator: '.'
-      delimiter: "'"
-      significant: false
-      strip_insignificant_zeros: false
-      
     currency:
       format:
-        unit: 'CHF'
-        format: '%u %n'
-        separator: '.'
         delimiter: "'"
+        format: '%u %n'
         precision: 2
+        separator: '.'
         significant: false
         strip_insignificant_zeros: false
-        
+        unit: 'CHF'
+    format:
+      delimiter: "'"
+      precision: 2
+      separator: '.'
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: "'"
-        
     precision:
       format:
         delimiter: "'"

--- a/lib/currency-locales/locales/he.yml
+++ b/lib/currency-locales/locales/he.yml
@@ -1,0 +1,49 @@
+---
+he:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "₪"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: מיליארד
+          million: מיליון
+          quadrillion: קודריליון
+          thousand: אלף
+          trillion: טריליון
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: בייט
+            other: בתים
+          gb: ג'יגה-בייט
+          kb: קילו-בייט
+          mb: מגה-בייט
+          tb: טרה-בייט
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/hi-IN.yml
+++ b/lib/currency-locales/locales/hi-IN.yml
@@ -1,0 +1,49 @@
+---
+hi-IN:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "₹"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: अरब
+          million: मिल्लिओंन
+          quadrillion: करोड़ शंख
+          thousand: हज़ार
+          trillion: खरब
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/hi.yml
+++ b/lib/currency-locales/locales/hi.yml
@@ -1,0 +1,49 @@
+---
+hi:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "₹"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: अरब
+          million: दस करोड़
+          quadrillion: करोड़ शंख
+          thousand: हज़ार
+          trillion: खरब
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/hr.yml
+++ b/lib/currency-locales/locales/hr.yml
@@ -1,26 +1,23 @@
 hr:
   number:
-    format:
-      precision: 2
-      separator: ","
-      delimiter: "."
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        unit: 'kn'
-        precision: 2
-        format: '%n %u'
-        separator: ","
         delimiter: "."
+        format: '%n %u'
+        precision: 2
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-
+        unit: 'kn'
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: "."
-        
     precision:
       format:
         delimiter: "."

--- a/lib/currency-locales/locales/hu.yml
+++ b/lib/currency-locales/locales/hu.yml
@@ -1,30 +1,26 @@
 hu:
   number:
-    format:
-      precision: 2
-      separator: ","
-      delimiter: " "
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: '%n %u'
-        unit: 'Ft'
-        separator: ","
         delimiter: " "
+        format: '%n %u'
         precision: 0
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-
+        unit: 'Ft'
+    format:
+      delimiter: " "
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-        
     precision:
       format:
         delimiter: " "
-        
     paypal:
       format:
         precision: 0

--- a/lib/currency-locales/locales/hy.yml
+++ b/lib/currency-locales/locales/hy.yml
@@ -1,0 +1,55 @@
+---
+hy:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        negative_format: "-%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Միլիարդ
+          million: Միլիոն
+          quadrillion: Քառյակ
+          thousand: Հազար
+          trillion: Տրիլիոն
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Բայթ
+            other: Բայթ
+          eb: ԷԲ
+          gb: ԳԲ
+          kb: ԿԲ
+          mb: ՄԲ
+          pb: ՊԲ
+          tb: ՏԲ
+          zb: ԶԲ
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/id.yml
+++ b/lib/currency-locales/locales/id.yml
@@ -1,0 +1,50 @@
+---
+id:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u%n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: Rp
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Miliar
+          million: Juta
+          quadrillion: Quadriliun
+          thousand: Ribu
+          trillion: Triliun
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Byte
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/il.yml
+++ b/lib/currency-locales/locales/il.yml
@@ -1,26 +1,23 @@
 il:
   number:
-    format:
-      separator: "."
-      delimiter: ","
-      precision: 2  
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%u %n"
-        unit: "₪"
-        separator: "."
         delimiter: ","
+        format: "%u %n"
         precision: 2
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "₪"
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: ","

--- a/lib/currency-locales/locales/is.yml
+++ b/lib/currency-locales/locales/is.yml
@@ -1,0 +1,58 @@
+---
+is:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: kr.
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: milljarður
+            other: milljarðar
+          million:
+            one: milljón
+            other: milljónir
+          quadrillion:
+            one: billjarður
+            other: billjarðar
+          thousand: þúsund
+          trillion:
+            one: billjón
+            other: billjónir
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: bæti
+            other: bæti
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/it-CH.yml
+++ b/lib/currency-locales/locales/it-CH.yml
@@ -1,0 +1,52 @@
+---
+it-CH:
+  number:
+    currency:
+      format:
+        delimiter: "'"
+        format: "%u %n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: CHF
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Miliardi
+          million: Milioni
+          quadrillion: Biliardi
+          thousand: Mila
+          trillion: Bilioni
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Byte
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/it.yml
+++ b/lib/currency-locales/locales/it.yml
@@ -1,0 +1,52 @@
+---
+it:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Miliardi
+          million: Milioni
+          quadrillion: Biliardi
+          thousand: Mila
+          trillion: Bilioni
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Byte
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/ja.yml
+++ b/lib/currency-locales/locales/ja.yml
@@ -1,30 +1,26 @@
 ja:
   number:
     format:
-      separator: "."
       delimiter: ","
       precision: 2
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%u%n"
-        unit: "¥"
-        separator: ""
         delimiter: ","
+        format: "%u%n"
         precision: 0
+        separator: ""
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "¥"
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: ","
-        
     paypal:
       format:
         precision: 0

--- a/lib/currency-locales/locales/ja.yml
+++ b/lib/currency-locales/locales/ja.yml
@@ -1,11 +1,5 @@
 ja:
   number:
-    format:
-      delimiter: ","
-      precision: 2
-      separator: "."
-      significant: false
-      strip_insignificant_zeros: false
     currency:
       format:
         delimiter: ","
@@ -15,6 +9,12 @@ ja:
         significant: false
         strip_insignificant_zeros: false
         unit: "¥"
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""

--- a/lib/currency-locales/locales/ka.yml
+++ b/lib/currency-locales/locales/ka.yml
@@ -1,0 +1,50 @@
+---
+ka:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: ლ
+    format:
+      delimiter: " "
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: მილიარდი
+          million: მილიონი
+          quadrillion: კვადრილიონი
+          thousand: ათასი
+          trillion: ტრილიონი
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: ბაიტი
+            other: ბაიტები
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/kk.yml
+++ b/lib/currency-locales/locales/kk.yml
@@ -1,0 +1,62 @@
+---
+kk:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: теңге
+    format:
+      delimiter: " "
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: миллиард
+            other: миллиард
+          million:
+            one: миллион
+            other: миллион
+          quadrillion:
+            one: квадриллион
+            other: квадриллион
+          thousand:
+            one: мың
+            other: мың
+          trillion:
+            one: триллион
+            other: триллион
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: байт
+            other: байт
+          eb: ЭБ
+          gb: ГБ
+          kb: КБ
+          mb: МБ
+          pb: ПБ
+          tb: ТБ
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/km.yml
+++ b/lib/currency-locales/locales/km.yml
@@ -1,0 +1,39 @@
+---
+km:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "៛"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: ប៊ីលាន
+          million: លាន
+          quadrillion: ក្វាទ្រីលាន
+          thousand: ពាន់
+          trillion: ទ្រីលាន
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/kn.yml
+++ b/lib/currency-locales/locales/kn.yml
@@ -1,0 +1,49 @@
+---
+kn:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: ಲಕ್ಷಕೋಟಿ
+          million: ದಶಲಕ್ಷ
+          quadrillion: ಪದ್ಮ
+          thousand: ಸಾವಿರ
+          trillion: ನೀಲ್
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/ko.yml
+++ b/lib/currency-locales/locales/ko.yml
@@ -1,0 +1,51 @@
+---
+ko:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 원
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n%u"
+        units:
+          billion: 십억
+          million: 백만
+          quadrillion: 천조
+          thousand: 천
+          trillion: 조
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: 바이트
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/lb.yml
+++ b/lib/currency-locales/locales/lb.yml
@@ -1,0 +1,52 @@
+---
+lb:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Milliard
+          million: Millioun
+          quadrillion:
+            one: Billiard
+            other: Billiarden
+          thousand: Dausend
+          trillion: Billioun
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Byten
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/lo.yml
+++ b/lib/currency-locales/locales/lo.yml
@@ -1,0 +1,48 @@
+---
+lo:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: Kip
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            zero: Bytes
+            one: Byte
+            two: Bytes
+            few: Bytes
+            many: Bytes
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/lt.yml
+++ b/lib/currency-locales/locales/lt.yml
@@ -1,0 +1,54 @@
+---
+lt:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: " "
+      precision: 3
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Milijardas
+          million: Milijonas
+          quadrillion: Kvadrilijonas
+          thousand: Tūkstantis
+          trillion: Trilijonas
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Baitas
+            few: Baitai
+            other: Baitų
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/lv.yml
+++ b/lib/currency-locales/locales/lv.yml
@@ -1,0 +1,68 @@
+---
+lv:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            zero: miljardi
+            one: miljards
+            other: miljardi
+          million:
+            zero: miljoni
+            one: miljons
+            other: miljoni
+          quadrillion:
+            zero: kvadriljoni
+            one: kvadriljons
+            other: kvadriljoni
+          thousand:
+            zero: tūkstoši
+            one: tūkstotis
+            other: tūkstoši
+          trillion:
+            zero: triljoni
+            one: triljons
+            other: triljoni
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            zero: baiti
+            one: baits
+            other: baiti
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/mg.yml
+++ b/lib/currency-locales/locales/mg.yml
@@ -1,0 +1,52 @@
+---
+mg:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: Ar
+    format:
+      delimiter: " "
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: tapitrisa
+          million: hetsy
+          quadrillion: hetsy tapitrisa
+          thousand: Arivo
+          trillion: arivo tapitrisa
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: octet
+            other: octets
+          eb: Eo
+          gb: Go
+          kb: ko
+          mb: Mo
+          pb: Po
+          tb: To
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/mk.yml
+++ b/lib/currency-locales/locales/mk.yml
@@ -1,0 +1,49 @@
+---
+mk:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: MKD
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: илјади
+          million: милјони
+          quadrillion: милјарди
+          thousand: трилјони
+          trillion: квадрилјони
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: бајт
+            other: бајти
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/ml.yml
+++ b/lib/currency-locales/locales/ml.yml
@@ -1,0 +1,55 @@
+---
+ml:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        negative_format: "-%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "₹"
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: നൂറുകോടി
+          million: ദശലക്ഷം
+          quadrillion: ക്വാഡ്രില്യൺ
+          thousand: ആയിരം
+          trillion: ട്രില്യൺ
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: ബൈറ്റ്
+            other: ബൈറ്റുകൾ
+          eb: ഇ.ബി
+          gb: ജി.ബി
+          kb: കെ.ബി.
+          mb: എം.ബി.
+          pb: പി.ബി
+          tb: ടി.ബി
+          zb: സി.ബി
+    percentage:
+      format:
+        delimiter: ''
+        format: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/mn.yml
+++ b/lib/currency-locales/locales/mn.yml
@@ -1,0 +1,49 @@
+---
+mn:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: төг.
+    format:
+      delimiter: " "
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Тэрбум
+          million: Сая
+          quadrillion: Тунамал
+          thousand: Мянга
+          trillion: Их наяд
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Байт
+            other: Байт
+          gb: ГБ
+          kb: КБ
+          mb: МБ
+          tb: ТБ
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/mr-IN.yml
+++ b/lib/currency-locales/locales/mr-IN.yml
@@ -1,0 +1,49 @@
+---
+mr-IN:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "₹"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: अब्ज
+          million: दशलक्ष
+          quadrillion: एकावर १५ शून्य इतकी संख्या
+          thousand: हजार
+          trillion: एकावर १२ शून्ये इतकी संख्या
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/ms-MY.yml
+++ b/lib/currency-locales/locales/ms-MY.yml
@@ -1,26 +1,23 @@
 ms-MY:
   number:
-    format:
-      separator: "."
-      delimiter: ","
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%u %n"
-        unit: "RM"
-        separator: "."
         delimiter: ","
+        format: "%u %n"
         precision: 2
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "RM"
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: ","

--- a/lib/currency-locales/locales/ms.yml
+++ b/lib/currency-locales/locales/ms.yml
@@ -1,0 +1,49 @@
+---
+ms:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: RM
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Ribu Juta
+          million: Juta
+          quadrillion: Juta-juta
+          thousand: Ribu
+          trillion: Trilion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Bait
+            other: Bait
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/nb.yml
+++ b/lib/currency-locales/locales/nb.yml
@@ -1,26 +1,23 @@
 nb:
   number:
-    format:
-      precision: 2
-      separator: ","
-      delimiter: " "
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        unit: "kr"
+        delimiter: " "
         format: "%n %u"
         precision: 2
         separator: ","
-        delimiter: " "
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "kr"
+    format:
+      delimiter: " "
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: " "

--- a/lib/currency-locales/locales/ne.yml
+++ b/lib/currency-locales/locales/ne.yml
@@ -1,0 +1,49 @@
+---
+ne:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: रू
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: अर्ब
+          million: Million
+          quadrillion: Quadrillion
+          thousand: हजार
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: जि.बी.
+          kb: के.बी.
+          mb: एम.बी
+          tb: टि.बी
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/nl.yml
+++ b/lib/currency-locales/locales/nl.yml
@@ -1,0 +1,50 @@
+---
+nl:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u %n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: miljard
+          million: miljoen
+          quadrillion: biljard
+          thousand: duizend
+          trillion: biljoen
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: byte
+            other: bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/nn.yml
+++ b/lib/currency-locales/locales/nn.yml
@@ -1,0 +1,58 @@
+---
+nn:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: kr
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: milliard
+            other: milliardar
+          million:
+            one: million
+            other: millionar
+          quadrillion:
+            one: billiard
+            other: billiardar
+          thousand: tusen
+          trillion:
+            one: billion
+            other: billionar
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: kB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/oc.yml
+++ b/lib/currency-locales/locales/oc.yml
@@ -1,0 +1,49 @@
+---
+oc:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: miliard
+          million: milion
+          quadrillion: milion de miliards
+          thousand: mila
+          trillion: bilion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: octet
+            other: octets
+          gb: Go
+          kb: ko
+          mb: Mo
+          tb: To
+    percentage:
+      format:
+        delimiter: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/or.yml
+++ b/lib/currency-locales/locales/or.yml
@@ -1,0 +1,49 @@
+---
+or:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "₹"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: ମିଥ୍ଯା
+      strip_insignificant_zeros: ମିଥ୍ଯା
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: ବିଲିୟନ୍
+          million: ମିଲିୟନ୍
+          quadrillion: ହଜାର ବିଲିୟନ୍
+          thousand: ହଜାର
+          trillion: ଟ୍ରିଲିୟନ୍
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/pa.yml
+++ b/lib/currency-locales/locales/pa.yml
@@ -1,0 +1,50 @@
+---
+pa:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: ਬਿਲੀਅਨ
+          million: ਮਿਲੀਅਨ
+          quadrillion: ਕ੍ਵਾਡਰਿਲੀਅਨ
+          thousand: ਹਜ਼ਾਰ
+          trillion: ਟ੍ਰਿਲੀਅਨ
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: ਬਾਈਟ
+            other: ਬਾਈਟ
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/pap-AW.yml
+++ b/lib/currency-locales/locales/pap-AW.yml
@@ -1,0 +1,52 @@
+---
+pap-AW:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u%n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: ANG
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: bion
+          million: mion
+          quadrillion: kuatrion
+          thousand: mil
+          trillion: trion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: bèrdat
+        strip_insignificant_zeros: bèrdat
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Bait
+            other: Bait
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+          pb: PB
+          eb: EB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/pap-CW.yml
+++ b/lib/currency-locales/locales/pap-CW.yml
@@ -1,0 +1,52 @@
+---
+pap-CW:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u%n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: ANG
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: bion
+          million: mion
+          quadrillion: kuatrion
+          thousand: mil
+          trillion: trion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: bèrdat
+        strip_insignificant_zeros: bèrdat
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Bait
+            other: Bait
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+          pb: PB
+          eb: EB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/pl.yml
+++ b/lib/currency-locales/locales/pl.yml
@@ -1,26 +1,23 @@
 pl:
   number:
-    format:
-      separator: ","
-      delimiter: " "
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%n %u"
-        unit: "zł"
-        separator: ","
         delimiter: " "
+        format: "%n %u"
         precision: 2
+        separator: ","
         significant: false
         strip_insignificant_zeros: true
-
+        unit: "zł"
+    format:
+      delimiter: " "
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: " "

--- a/lib/currency-locales/locales/pt-BR.yml
+++ b/lib/currency-locales/locales/pt-BR.yml
@@ -1,26 +1,23 @@
 pt-BR:
   number:
-    format:
-      separator: ","
-      delimiter: "."
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%u %n"
-        unit: "R$"
-        separator: ","
         delimiter: "."
+        format: "%u %n"
         precision: 2
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "R$"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: "."

--- a/lib/currency-locales/locales/pt.yml
+++ b/lib/currency-locales/locales/pt.yml
@@ -1,0 +1,63 @@
+---
+pt:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        negative_format: "-%u%n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: mil milhões
+            other: mil milhões
+          million:
+            one: milhão
+            other: milhões
+          quadrillion:
+            one: mil biliões
+            other: mil biliões
+          thousand: mil
+          trillion:
+            one: bilião
+            other: biliões
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+          zb: ZB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/rm.yml
+++ b/lib/currency-locales/locales/rm.yml
@@ -1,0 +1,48 @@
+---
+rm:
+  number:
+    currency:
+      format:
+        delimiter: "'"
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: CHF
+    format:
+      delimiter: "'"
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            zero: bytes
+            one: byte
+            two: bytes
+            few: bytes
+            many: bytes
+            other: bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/ro.yml
+++ b/lib/currency-locales/locales/ro.yml
@@ -1,26 +1,23 @@
 ro:
   number:
-    format:
-      separator: ","
-      delimiter: "."
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%n %u"
-        unit: "lei"
-        separator: ","
         delimiter: "."
+        format: "%n %u"
         precision: 2
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "lei"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: "."

--- a/lib/currency-locales/locales/ru.yml
+++ b/lib/currency-locales/locales/ru.yml
@@ -1,0 +1,75 @@
+---
+ru:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: руб.
+    format:
+      delimiter: " "
+      precision: 3
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: миллиард
+            few: миллиардов
+            many: миллиардов
+            other: миллиардов
+          million:
+            one: миллион
+            few: миллионов
+            many: миллионов
+            other: миллионов
+          quadrillion:
+            one: квадриллион
+            few: квадриллионов
+            many: квадриллионов
+            other: квадриллионов
+          thousand:
+            one: тысяча
+            few: тысяч
+            many: тысяч
+            other: тысяч
+          trillion:
+            one: триллион
+            few: триллионов
+            many: триллионов
+            other: триллионов
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: байт
+            few: байта
+            many: байт
+            other: байта
+          eb: ЭБ
+          gb: ГБ
+          kb: КБ
+          mb: МБ
+          pb: ПБ
+          tb: ТБ
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/sc.yml
+++ b/lib/currency-locales/locales/sc.yml
@@ -1,0 +1,59 @@
+---
+sc:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: milliardu
+            other: milliardos
+          million:
+            one: millione
+            other: milliones
+          quadrillion:
+            one: cuadrillione
+            other: cuadrilliones
+          thousand: mìgia
+          trillion: mìgia milliardos
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Byte
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/sk.yml
+++ b/lib/currency-locales/locales/sk.yml
@@ -1,0 +1,50 @@
+---
+sk:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: " "
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Miliarda
+          million: Milión
+          quadrillion: Biliarda
+          thousand: Tisíc
+          trillion: Bilión
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: B
+            few: B
+            other: B
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: " "
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/sl.yml
+++ b/lib/currency-locales/locales/sl.yml
@@ -1,0 +1,46 @@
+---
+sl:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u%n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            two: Bytes
+            few: Bytes
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/sq.yml
+++ b/lib/currency-locales/locales/sq.yml
@@ -1,0 +1,52 @@
+---
+sq:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Miliard
+          million: Milion
+          quadrillion: Kuadrilion
+          thousand: Mijë
+          trillion: Trilion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Bajt
+            other: Bajte
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/sr.yml
+++ b/lib/currency-locales/locales/sr.yml
@@ -1,0 +1,72 @@
+---
+sr:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: РСД
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: милијарда
+            few: милијарде
+            many: милијарди
+            other: милијарди
+          million:
+            one: милион
+            few: милиона
+            many: милиона
+            other: милиона
+          quadrillion:
+            one: квадрилион
+            few: квадрилиона
+            many: квадрилиона
+            other: квадрилиона
+          thousand:
+            one: хиљада
+            few: хиљаде
+            many: хиљада
+            other: хиљада
+          trillion:
+            one: трилион
+            few: трилиона
+            many: трилиона
+            other: трилиона
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: бајт
+            few: бајта
+            many: бајтова
+            other: бајтова
+          gb: ГБ
+          kb: КБ
+          mb: МБ
+          tb: ТБ
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/st.yml
+++ b/lib/currency-locales/locales/st.yml
@@ -1,0 +1,52 @@
+---
+st:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: M
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Bilione
+          million: Milione
+          quadrillion: Libilione tse likete
+          thousand: Sekete
+          trillion: Trilione
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/sv-FI.yml
+++ b/lib/currency-locales/locales/sv-FI.yml
@@ -1,0 +1,53 @@
+---
+sv-FI:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: " "
+      precision: 2
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Miljard
+          million: Miljon
+          quadrillion: Biljard
+          thousand: Tusen
+          trillion: Biljon
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: " "
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/sv-SE.yml
+++ b/lib/currency-locales/locales/sv-SE.yml
@@ -1,26 +1,23 @@
 sv-SE:
   number:
-    format:
-      separator: ","
-      delimiter: " "
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%n %u"
-        unit: "kr"
-        separator: ","
         delimiter: " "
+        format: "%n %u"
         precision: 2
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "kr"
+    format:
+      delimiter: " "
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: " "

--- a/lib/currency-locales/locales/sv.yml
+++ b/lib/currency-locales/locales/sv.yml
@@ -1,0 +1,53 @@
+---
+sv:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: kr
+    format:
+      delimiter: " "
+      precision: 2
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Miljard
+          million: Miljon
+          quadrillion: Biljard
+          thousand: Tusen
+          trillion: Biljon
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: " "
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/sw.yml
+++ b/lib/currency-locales/locales/sw.yml
@@ -1,0 +1,47 @@
+---
+sw:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n%u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "/="
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Bilioni
+          million: Milioni
+          quadrillion: Kuadrilioni
+          thousand: Elfu
+          trillion: Trilioni
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte: Baiti
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/ta.yml
+++ b/lib/currency-locales/locales/ta.yml
@@ -1,0 +1,50 @@
+---
+ta:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "₹"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: பில்லியன்
+          million: மில்லியன்
+          quadrillion: குவாட்ரில்லியன்
+          thousand: ஆயிரம்
+          trillion: டிரில்லியன்
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/te.yml
+++ b/lib/currency-locales/locales/te.yml
@@ -1,0 +1,50 @@
+---
+te:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "₹"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: బిలియన్
+          million: మిలియన్
+          quadrillion: క్వాడ్రిలియన్
+          thousand: వెయ్యి
+          trillion: ట్రిలియన్
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: బైట్
+            other: బైట్లు
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/th.yml
+++ b/lib/currency-locales/locales/th.yml
@@ -1,26 +1,23 @@
 th:
   number:
-    format:
-      separator: "."
-      delimiter: ","
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%u %n"
-        unit: "฿"
-        separator: "."
         delimiter: ","
+        format: "%u %n"
         precision: 2
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "฿"
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: ","

--- a/lib/currency-locales/locales/tl.yml
+++ b/lib/currency-locales/locales/tl.yml
@@ -1,0 +1,49 @@
+---
+tl:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "₱"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: bilyon
+          million: milyon
+          quadrillion: kuwadrilyon
+          thousand: libo
+          trillion: trilyon
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/tr.yml
+++ b/lib/currency-locales/locales/tr.yml
@@ -1,28 +1,25 @@
 tr:
   number:
-    format:
-      separator: ","
-      delimiter: "."
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-
     currency:
       format:
-        format: "%u%n"
-        unit: "₺"
-        separator: ","
         delimiter: "."
+        format: "%u%n"
         precision: 2
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-
+        unit: "₺"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: '.'
         separator: ','
         precision: 2
-        
     precision:
       format:
         delimiter: '.'

--- a/lib/currency-locales/locales/tt.yml
+++ b/lib/currency-locales/locales/tt.yml
@@ -1,0 +1,60 @@
+---
+tt:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: сум
+    format:
+      delimiter: " "
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: миллиард
+            other: миллиард
+          million:
+            one: миллион
+            other: миллион
+          quadrillion:
+            one: квадриллион
+            other: квадриллион
+          thousand:
+            one: мең
+            other: мең
+          trillion:
+            one: триллион
+            other: триллион
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: байт
+            other: байт
+          gb: ГБ
+          kb: КБ
+          mb: МБ
+          tb: ТБ
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/ug.yml
+++ b/lib/currency-locales/locales/ug.yml
@@ -1,0 +1,49 @@
+---
+ug:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u %n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: CN¥
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: مىليارد
+          million: مىليون
+          quadrillion: گېگابايت
+          thousand: مىڭ
+          trillion: مېگا
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: بايت
+            other: بايت
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/uk.yml
+++ b/lib/currency-locales/locales/uk.yml
@@ -1,0 +1,71 @@
+---
+uk:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "₴"
+    format:
+      delimiter: " "
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: Мільярд
+            few: Мільярдів
+            many: Мільярдів
+            other: Мільярдів
+          million:
+            one: Мільйон
+            few: Мільйонів
+            many: Мільйонів
+            other: Мільйонів
+          quadrillion:
+            one: Квадрильйон
+            few: Квадрильйонів
+            many: Квадрильйонів
+            other: Квадрильйонів
+          thousand:
+            one: Тисяча
+            few: Тисяч
+            many: Тисяч
+            other: Тисяч
+          trillion:
+            one: Трильйон
+            few: Трильйонів
+            many: Трильйонів
+            other: Трильйонів
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: байт
+            few: байти
+            many: байтів
+            other: байту
+          gb: ГБ
+          kb: кБ
+          mb: МБ
+          tb: ТБ
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/ur.yml
+++ b/lib/currency-locales/locales/ur.yml
@@ -1,0 +1,50 @@
+---
+ur:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: Rs
+    format:
+      delimiter: ","
+      precision: 0
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: بلین
+          million: ملین
+          quadrillion: کواڈریلن
+          thousand: ہزار
+          trillion: ٹریلن
+          unit: Rs
+      format:
+        delimiter: ''
+        precision: 0
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n فیصد"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/uz.yml
+++ b/lib/currency-locales/locales/uz.yml
@@ -1,0 +1,71 @@
+---
+uz:
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: so'm.
+    format:
+      delimiter: " "
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: milliard
+            few: milliard
+            many: milliard
+            other: milliard
+          million:
+            one: million
+            few: million
+            many: million
+            other: million
+          quadrillion:
+            one: kvadrillion
+            few: kvadrillion
+            many: kvadrillion
+            other: kvadrillion
+          thousand:
+            one: ming
+            few: ming
+            many: ming
+            other: ming
+          trillion:
+            one: trillion
+            few: trillion
+            many: trillion
+            other: trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: bayt
+            few: bayt
+            many: bayt
+            other: bayt
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/vi.yml
+++ b/lib/currency-locales/locales/vi.yml
@@ -1,0 +1,50 @@
+---
+vi:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 0
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: VNĐ
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Tỷ
+          million: Triệu
+          quadrillion: Triệu tỷ
+          thousand: Nghìn
+          trillion: Nghìn tỷ
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Byte
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/wo.yml
+++ b/lib/currency-locales/locales/wo.yml
@@ -1,0 +1,49 @@
+---
+wo:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/zh-CN.yml
+++ b/lib/currency-locales/locales/zh-CN.yml
@@ -1,0 +1,50 @@
+---
+zh-CN:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u %n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: CN¥
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十亿
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte: 字节
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/zh-HK.yml
+++ b/lib/currency-locales/locales/zh-HK.yml
@@ -1,0 +1,50 @@
+---
+zh-HK:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u %n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: HK$
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百萬
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''

--- a/lib/currency-locales/locales/zh-TW.yml
+++ b/lib/currency-locales/locales/zh-TW.yml
@@ -1,30 +1,26 @@
 zh-TW:
   number:
-    format:
-      separator: "."
-      delimiter: ","
-      precision: 2
-      significant: false
-      strip_insignificant_zeros: false
-      
     currency:
       format:
-        format: "%u %n"
-        unit: "NT$"
-        separator: "."
         delimiter: ","
+        format: "%u %n"
         precision: 2
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        
+        unit: "NT$"
+    format:
+      delimiter: ","
+      precision: 2
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
-        
     precision:
       format:
         delimiter: ","
-    
     paypal:
       format:
         precision: 0

--- a/lib/currency-locales/locales/zh-YUE.yml
+++ b/lib/currency-locales/locales/zh-YUE.yml
@@ -1,0 +1,50 @@
+---
+zh-YUE:
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u %n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: HK$
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百萬
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''


### PR DESCRIPTION
- **Reorder currency to make it easier to compare diffs to Rails i18n**

### Making of this PR

Every existing locale files was
- reordered alphabetically by top level key
- _except_ the unusual/custom "paypal" key used in a few of our locales was left _at the end_ since its not going to be part of the ongoing locale updates
- each stanza was sorted alphabetically using my editor (sublimetext in this case)

Then each file was checked to make sure the keys were in the proper indentation visually, and the diffs from moving the bits around

A prequel to https://linear.app/bigcartel/issue/CRUST-1095/update-the-allowed-currency-list

Diffing is going to be a lot easier if we can check the differences more easily. 

Part of https://linear.app/bigcartel/issue/CRUST-1228/update-bigcartel-currency-locales
